### PR TITLE
Renovate 設定(renovate.json)を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":dependencyDashboard"
+  ],
+  "rangeStrategy": "pin",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "timezone": "Asia/Tokyo",
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "description": [
+        "メジャー更新は破壊的変更のリスクが高いため、安定する(枯れる)まで長めに待ってからPRを作成する。",
+        "minor/patchはグローバルのminimumReleaseAge(7日)のまま。",
+        "セキュリティ更新はvulnerabilityAlertsのデフォルト(minimumReleaseAge:null, prCreation:immediate)で即時PRになるため影響しない。"
+      ],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "30 days"
+    },
+    {
+      "description": [
+        "pin更新は既に解決済みの現行バージョンへ範囲を固定するだけで、新規バージョンの取り込みではない。",
+        "そのためpin対象バージョンにはreleaseTimestampが付与されず、グローバルのminimumReleaseAge(7日)+",
+        "minimumReleaseAgeBehaviour:timestamp-required(デフォルト)+internalChecksFilter:strictの下では",
+        "「タイムスタンプ無し=判定不能=pending」として除外され、pin PRが update failure になる。",
+        "pinは安定待機の対象とする意味がないため、minimumReleaseAgeの待機を解除する。",
+        "なおこのリポジトリはGitHub Actionとして依存をnccでdist/にバンドルして配布するアプリケーション型であり、",
+        "npmライブラリとしてpublishしないため、dependenciesも含め全依存をpinしてよい。"
+      ],
+      "matchUpdateTypes": ["pin"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": [
+        "action.ymlのNodeランタイム(customManagers参照)の更新候補を「偶数メジャーのみ」のタグに制限する。",
+        "GitHub Actionsのrunエンジンが受け付けるのは node16/node20/node24 のようなメジャーのみの識別子で、",
+        "かつ偶数(LTS)メジャーしかサポートされないため。",
+        "dockerデータソースのnodeイメージには 16.20.2 や 21 のようなタグも存在するので、この制限がないと不正値になる。"
+      ],
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["node"],
+      "allowedVersions": "/^\\d*[02468]$/"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": [
+        "action.ymlのGitHub Actionランタイム(runs.using: node16 等)を追従更新する。",
+        "この値を拾う組み込みmanagerは存在しない。",
+        "node-versionデータソースはフルバージョン(例: 20.11.1)を返すため、グローバルのrangeStrategy:pinと組み合わさると",
+        "node20.11.1のような不正値に書き換えられてしまう。",
+        "そのため、素のメジャーのみのタグ(16/20/24等)を持つDocker Hub公式nodeイメージをdockerデータソースとして参照し、",
+        "packageRulesのallowedVersionsで偶数メジャーのみに制限している。",
+        "注意: ランタイム更新時はdist/の再ビルド(yarn build)と@types/node等の整合も必要なため、PRをそのままマージせず確認すること。",
+        "また、GitHubランナーが新しいnodeメジャーに対応するまでラグがある場合は、対応を待ってからマージすること。"
+      ],
+      "managerFilePatterns": ["/^action\\.ya?ml$/"],
+      "matchStrings": ["using:\\s*[\"']?node(?<currentValue>\\d+)[\"']?"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

依存関係の自動更新のため、Renovate の設定ファイル(`renovate.json`)を新規追加します。

## 設定内容

### ベース
- `config:recommended` + `helpers:pinGitHubActionDigestsToSemver`(Actions をコミット digest に固定しつつ semver コメントで可読性維持) + Dependency Dashboard
- `minimumReleaseAge: 7 days` + `internalChecksFilter: strict` — リリース直後のバージョンを掴まない(サプライチェーン攻撃対策)。メジャー更新は 30 日待機。セキュリティ更新(vulnerability alert)は即時 PR。
- `prConcurrentLimit` / `prHourlyLimit` を解除し、更新 PR を出揃わせて全体を見ながら処理できるようにする(このリポジトリは CI ワークフローがないため PR 大量作成による CI 消費の懸念もなし)

### rangeStrategy: pin(全体)
このリポジトリは GitHub Action として依存を ncc で `dist/` にバンドルして配布するアプリケーション型で、npm ライブラリとして publish しないため、`dependencies` も含め全依存を pin します。あわせて、pin 更新が `minimumReleaseAge` の pending 判定で update failure になる既知の罠への対策ルール(`matchUpdateTypes: ["pin"]` → `minimumReleaseAge: null`)を入れています。

### action.yml の Node ランタイム追従(customManager)
`runs.using: node16`(GitHub 非推奨のランタイム)は組み込み manager が拾わないため、regex customManager で追従します。node-version データソースだと `rangeStrategy: pin` によって `node20.11.1` のような不正値になるため、メジャーのみのタグを持つ Docker Hub 公式 node イメージを docker データソースとして参照し、`allowedVersions` で偶数(LTS)メジャーのみに制限しています。

## 補足・注意点

- **lockfile は yarn.lock (v1) です**(package-lock.json ではありません)。Renovate の npm manager は yarn.lock も扱うため設定はこのままで機能します。
- Renovate は `package.json` / `yarn.lock` を更新しますが **`dist/` の再ビルドは行いません**。更新 PR のマージ時は `yarn build` で `dist/` を再生成する運用(または CI での自動ビルド)が必要です。
- 導入直後は依存が古いため(default ブランチに Dependabot alert 65 件)、PR がまとまって作成される想定です。
- 検証済み: `renovate-config-validator`(renovate 43.251.3)でエラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)