### PR TITLE
v0.2.1リリース準備(README使用例の更新とバージョン更新)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ on:
 jobs:
   magic-pod-test:
     needs: deploy-stg
-    uses: buysell-technologies/magic-pod-action@v0.1
+    uses: buysell-technologies/magic-pod-action@v0.2
     with:
       API_TOKEN: ${{ secrets.MAGIC_POD_API_TOKEN }}
       ORGANIZATION: your-organization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-pod-action",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-pod-action",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-pod-action",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "repository": "git@github.com:buysell-technologies/magic-pod-action.git",
   "license": "MIT",


### PR DESCRIPTION
## 概要

v0.2.1 リリースに向けた準備です。

## 変更内容

- README の使用例の参照タグを `@v0.1` → `@v0.2` に更新(v0.1 は node16 ランタイムの旧版のため)
- `package.json` の `version` を `0.2.1` へ更新(#37 #38 #39 の取り込み分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)